### PR TITLE
Moodle 2.7 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.8
+
+- Updates deprecated context functions.
+- adds GPL declarations
+- adds setType statements missed in the upgrade to Moodle 2.5.
+
 ## v1.1.7
 
 - Ships with jQuery [#43][43]

--- a/block_cps.php
+++ b/block_cps.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class block_cps extends block_list {
     function init() {
         $this->title= get_string('pluginname', 'block_cps');

--- a/classes/lib.php
+++ b/classes/lib.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/enrol/ues/publiclib.php';
 ues::require_daos();
 

--- a/creation.php
+++ b/creation.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'creation_form.php';

--- a/creation_form.php
+++ b/creation_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->libdir . '/formslib.php';
 require_once $CFG->libdir . '/completionlib.php';
 

--- a/crosslist.php
+++ b/crosslist.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'crosslist_form.php';
@@ -29,7 +50,7 @@ $_s = ues::gen_str('block_cps');
 $blockname = $_s('pluginname');
 $heading = cps_crosslist::name();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 $PAGE->set_context($context);
 $PAGE->set_heading($blockname . ': '. $heading);

--- a/crosslist_form.php
+++ b/crosslist_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/cps/formslib.php';
 
 abstract class crosslist_form extends cps_form {

--- a/db/events.php
+++ b/db/events.php
@@ -1,4 +1,27 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * Events declarations.
+ * 
+ * @package    block_cps
+ * @copyright  2014, Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 $gen_mapper = function ($module) {
     return function ($event) use ($module) {

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 function xmldb_block_cps_upgrade($oldversion) {
     global $DB, $CFG;
 

--- a/events/lib.php
+++ b/events/lib.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/ues_meta_viewer/classes/lib.php';
 
 class cps_meta_ui_element extends meta_data_text_box {

--- a/events/simple_restore.php
+++ b/events/simple_restore.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 abstract class cps_simple_restore_handler {
     public static function simple_restore_complete($params) {
         global $DB, $CFG, $USER;

--- a/events/ues.php
+++ b/events/ues.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/cps/classes/lib.php';
 
 abstract class cps_profile_field_helper {

--- a/events/ues_meta_viewer.php
+++ b/events/ues_meta_viewer.php
@@ -1,5 +1,27 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ * Event handlers for ues_meta_viewer events.
+ *
+ * @package    block_cps
+ * @copyright  2014, Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/cps/events/lib.php';
 
 abstract class cps_ues_meta_viewer_handler {

--- a/events/ues_people.php
+++ b/events/ues_people.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/cps/events/ues_people_lib.php';
 
 abstract class cps_ues_people_handler {

--- a/events/ues_people_lib.php
+++ b/events/ues_people_lib.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/ues_people/lib.php';
 
 class cps_people_element extends ues_people_element_output {

--- a/formslib.php
+++ b/formslib.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->libdir . '/formslib.php';
 
 interface generic_states {
@@ -61,6 +82,7 @@ abstract class cps_form extends moodleform implements generic_states {
         }
 
         $class = $prefix . '_form_' . $state;
+mtrace(sprintf("creating form %s", $class));
 
         $data = $class::build($courses);
 

--- a/lang/en/block_cps.php
+++ b/lang/en/block_cps.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 $string['pluginname'] = 'Course Preferences';
 $string['pluginname_desc'] = 'The Course Preferences block allows instructors to
 control course creation and enrollment behavior. These are system wide defaults for

--- a/material.php
+++ b/material.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'material_form.php';
@@ -29,7 +50,7 @@ $_s = ues::gen_str('block_cps');
 $blockname = $_s('pluginname');
 $heading = cps_material::name();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 $PAGE->set_context($context);
 $PAGE->set_heading($blockname . ': '. $heading);

--- a/material_form.php
+++ b/material_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->libdir . '/formslib.php';
 
 class material_form extends moodleform {

--- a/setting.php
+++ b/setting.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'setting_form.php';
@@ -27,7 +48,7 @@ $_s = ues::gen_str('block_cps');
 $blockname = $_s('pluginname');
 $heading = cps_setting::name();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 $base_url = new moodle_url('/blocks/cps/setting.php');
 

--- a/setting_form.php
+++ b/setting_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->libdir . '/formslib.php';
 
 class setting_form extends moodleform {

--- a/settings.php
+++ b/settings.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 defined('MOODLE_INTERNAL') or die();
 
 if ($ADMIN->fulltree) {

--- a/settingslib.php
+++ b/settingslib.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 // To be added in settings.php only
 class setting_processor {
     public static function creation($settings, $_s) {

--- a/split.php
+++ b/split.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'split_form.php';
@@ -35,7 +56,7 @@ $_s = ues::gen_str('block_cps');
 $blockname = $_s('pluginname');
 $heading = cps_split::name();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 $PAGE->set_context($context);
 $PAGE->set_heading($blockname . ': '. $heading);
@@ -50,7 +71,7 @@ $PAGE->requires->js('/blocks/cps/js/selection.js');
 $PAGE->requires->js('/blocks/cps/js/split.js');
 
 $form = cps_form::create('split', $valid_semesters);
-
+var_dump($_POST);
 if ($form->is_cancelled()) {
     redirect(new moodle_url('/my'));
 } else if ($data = $form->get_data()) {

--- a/split_form.php
+++ b/split_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/cps/formslib.php';
 
 abstract class split_form extends cps_form {
@@ -155,6 +176,7 @@ class split_form_update extends split_form implements updating_form {
         $grouping_lookup = array();
 
         $m->addElement('hidden', 'shells', $shells);
+        $m->setType('shells', PARAM_INT);
 
         $m->addElement('header', 'selected_course', self::_s('split_updating'));
 
@@ -176,7 +198,10 @@ class split_form_update extends split_form implements updating_form {
         foreach ($grouping_lookup as $number => $info) {
             foreach ($info as $name => $secs) {
                 $m->addElement('hidden', 'shell_name_'.$number.'_hidden', $name);
+                $m->setType('shell_name_'.$number.'_hidden', PARAM_ALPHANUMEXT);
+
                 $m->addElement('hidden', 'shell_values_'.$number, implode(',', $secs));
+                $m->setType('shell_values_'.$number, PARAM_ALPHANUMEXT);
             }
         }
 
@@ -201,6 +226,7 @@ class split_form_update extends split_form implements updating_form {
         $m->setDefault('split_option', self::REARRANGE);
 
         $m->addElement('hidden', 'selected', '');
+        $m->setType('selected', PARAM_ALPHANUMEXT);
 
         $this->generate_states_and_buttons();
     }
@@ -302,7 +328,9 @@ class split_form_decide extends split_form {
                 $shell_name->toHtml() . '<br/>' . $radio->toHtml() . $shell->toHtml();
 
             $m->addElement('hidden', 'shell_values_'.$groupingid, $shell_values);
+            $m->setType('shell_values_'.$groupingid, PARAM_ALPHANUMEXT);
             $m->addElement('hidden', 'shell_name_'.$groupingid.'_hidden', $shell_name_value);
+            $m->setType('shell_name_'.$groupingid.'_hidden', PARAM_ALPHANUMEXT);
         }
 
         $previous_label =& $m->createElement('static', 'available_sections',
@@ -316,8 +344,12 @@ class split_form_decide extends split_form {
         $m->addElement('html', $form_html);
 
         $m->addElement('hidden', 'shells', '');
+        $m->setType('shells', PARAM_INT);
+
         $m->addElement('hidden', 'reshelled', '');
+
         $m->addElement('hidden', 'selected', '');
+        $m->setType('selected', PARAM_ALPHANUMEXT);
 
         $this->generate_states_and_buttons();
     }
@@ -374,14 +406,22 @@ class split_form_confirm extends split_form {
             $html .= '</ul>';
 
             $m->addElement('static', 'shell_label_' . $number, $display . ' ' .$name, $html);
+            $m->setType('reshelled', PARAM_INT);
 
             $m->addElement('hidden', $namekey, $this->_customdata[$namekey]);
+            $m->setType($namekey, PARAM_ALPHANUM);
+
             $m->addElement('hidden', $valuekey, $this->_customdata[$valuekey]);
+            $m->setType($valuekey, PARAM_ALPHANUM);
         }
 
         $m->addElement('hidden', 'shells', $this->_customdata['shells']);
+        $m->setType('shells', PARAM_INT);
+
         $m->addElement('hidden', 'reshelled', '');
+
         $m->addElement('hidden', 'selected', '');
+        $m->setType('selected', PARAM_ALPHANUMEXT);
 
         $this->generate_states_and_buttons();
     }

--- a/team_request.php
+++ b/team_request.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'team_request_form.php';
@@ -31,7 +52,7 @@ $_s = ues::gen_str('block_cps');
 $blockname = $_s('pluginname');
 $heading = cps_team_request::name();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 $PAGE->set_context($context);
 $PAGE->set_heading($blockname . ': '. $heading);

--- a/team_request_form.php
+++ b/team_request_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/cps/formslib.php';
 
 interface team_states {
@@ -193,7 +214,18 @@ class team_request_form_update extends team_request_form {
 
             foreach ($query as $key => $value) {
                 $m->addElement('hidden', 'query'.$number.'['.$key.']', $value);
-                $ptype = $key == 'department' ? PARAM_ALPHA : PARAM_INT;
+                switch($key){
+                    case 'department':
+                        $ptype = PARAM_ALPHANUMEXT;
+                        break;
+                    case 'cou_number':
+                        $ptype = PARAM_ALPHANUM;
+                        break;
+                    default:
+                        $ptype = PARAM_INT;
+                        break;
+                }
+
                 $m->setType('query'.$number.'['.$key.']', $ptype);
             }
         }
@@ -497,7 +529,7 @@ class team_request_form_query extends team_request_form {
 
         if ($update_option) {
             $m->addElement('hidden', 'update_option', $update_option);
-
+            $m->setType('update_option',PARAM_INT);
             $this->prev = self::UPDATE;
         }
 
@@ -538,8 +570,8 @@ class team_request_form_query extends team_request_form {
 
             $group = $m->addGroup($texts, 'query' . $number, $display, $fill(1), true);
 
-            $m->setType($group->getElementName('department'), PARAM_ALPHA);
-            $m->setType($group->getElementName('cou_number'), PARAM_INT);
+            $m->setType($group->getElementName('department'), PARAM_ALPHANUMEXT);
+            $m->setType($group->getElementName('cou_number'), PARAM_ALPHANUM);
             
             $m->addElement('hidden', 'selected_users'.$number.'_str', '');
             $m->setType('selected_users'.$number.'_str', PARAM_TEXT);
@@ -658,6 +690,7 @@ class team_request_form_request extends team_request_form {
 
         if ($update_option) {
             $m->addElement('hidden', 'update_option', $update_option);
+            $m->setType('update_option', PARAM_INT);
             $adding_user = team_request_form_update::ADD_USER_CURRENT;
 
             $this->prev = $update_option == $adding_user ? self::UPDATE :
@@ -676,10 +709,10 @@ class team_request_form_request extends team_request_form {
             $query = $this->_customdata[$key];
 
             $m->addElement('hidden', 'query'.$number.'[department]', '');
-            $m->setType('query'.$number.'[department]', PARAM_ALPHA);
+            $m->setType('query'.$number.'[department]', PARAM_ALPHANUMEXT);
             
             $m->addElement('hidden', 'query'.$number.'[cou_number]', '');
-            $m->setType('query'.$number.'[cou_number]', PARAM_INT);
+            $m->setType('query'.$number.'[cou_number]', PARAM_ALPHANUM);
             
             if (empty($query['department'])) {
                 $m->addElement('hidden', 'selected_users'.$number, '');
@@ -800,10 +833,10 @@ class team_request_form_review extends team_request_form {
             $query = (object) $this->_customdata['query'. $number];
 
             $m->addElement('hidden', 'query'.$number.'[department]', '');
-            $m->setType('query'.$number.'[department]', PARAM_ALPHA);
+            $m->setType('query'.$number.'[department]', PARAM_ALPHANUMEXT);
             
             $m->addElement('hidden', 'query'.$number.'[cou_number]', '');
-            $m->setType('query'.$number.'[cou_number]', PARAM_INT);
+            $m->setType('query'.$number.'[cou_number]', PARAM_ALPHANUM);
 
             if (empty($query->department)) {
                 $m->addElement('hidden', 'selected_users'.$number.'_str', '');
@@ -839,6 +872,7 @@ class team_request_form_review extends team_request_form {
         $update_option = optional_param('update_option', null, PARAM_INT);
         if ($update_option) {
             $m->addElement('hidden', 'update_option', $update_option);
+            $m->setType('update_option', PARAM_INT);
         }
 
         $this->generate_states_and_buttons();

--- a/team_section.php
+++ b/team_section.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'team_section_form.php';
@@ -51,7 +72,7 @@ $_s = ues::gen_str('block_cps');
 $blockname = $_s('pluginname');
 $heading = cps_team_request::name();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 $PAGE->set_context($context);
 $PAGE->set_heading($blockname . ': '. $heading);

--- a/team_section_form.php
+++ b/team_section_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->dirroot . '/blocks/cps/formslib.php';
 
 abstract class team_section_form extends cps_form {

--- a/tests/fetch_sections_test.php
+++ b/tests/fetch_sections_test.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 global $CFG;
 
 

--- a/unwant.php
+++ b/unwant.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once '../../config.php';
 require_once 'classes/lib.php';
 require_once 'unwant_form.php';
@@ -30,7 +51,7 @@ $_s = ues::gen_str('block_cps');
 $blockname = $_s('pluginname');
 $heading = cps_unwant::name();
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = context_system::instance();
 
 $PAGE->set_context($context);
 $PAGE->set_heading($blockname . ': '. $heading);

--- a/unwant_form.php
+++ b/unwant_form.php
@@ -1,5 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+
+/**
+ *
+ * @package    block_cps
+ * @copyright  2014 Louisiana State University
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 require_once $CFG->libdir . '/formslib.php';
 
 class unwant_form extends moodleform {

--- a/version.php
+++ b/version.php
@@ -1,3 +1,36 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-$plugin->version = 2013081019;
+
+/**
+ * @package   block_cps
+ * @copyright 2014, Louisiana State University
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+ 
+defined('MOODLE_INTERNAL') || die();
+
+
+$plugin->version = 2014060600;
+$plugin->requires = 2013051400;
+$plugin->component = 'block_cps';
+$plugin->maturity = MATURITY_STABLE;
+$plugin->release = 'v1.1.8';
+
+
+$plugin->dependencies = array(
+    'enrol_ues' => 2013081007,
+);


### PR DESCRIPTION
- Updates deprecated function calls.
- Adds setType() statments to form definitions (missed at last upgrade).
- Update version to v1.1.8
- Adds GPL header.
- Declares dependency on UES (version.php).
